### PR TITLE
feat: open session in new terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Default trigger: `Option/Alt+e` (no prefix required)
 |-----|--------|
 | `↑` / `↓` or `j` / `k` | Move cursor |
 | `Enter` | Switch to session |
+| `o` | Open session in new terminal window |
 | `Number` | Jump to session N |
 | `Shift+↑/↓` or `Opt/Alt+↑/↓` | Reorder session |
 | `Shift`+`Number` | Pin to slot 1–10 |
@@ -48,5 +49,29 @@ bind-key e run-shell -b "$HOME/.tmux/plugins/quickdraw/scripts/quickdraw.sh"
 ```
 
 Check for conflicts: `tmux list-keys | grep M-e`
+
+### Open in new terminal window
+
+Press `o` in the quickdraw popup to open the highlighted session in a new terminal window instead of switching to it in the current one.
+
+Set your terminal emulator so quickdraw knows how to open a new window:
+
+```tmux
+set -g @quickdraw-terminal 'ghostty'
+```
+
+Supported terminals:
+
+| Value | Terminal | Platform |
+|-------|----------|----------|
+| `ghostty` | [Ghostty](https://ghostty.org) | macOS / Linux |
+| `alacritty` | [Alacritty](https://alacritty.org) | macOS / Linux |
+| `wezterm` | [WezTerm](https://wezfurlong.org/wezterm) | macOS / Linux |
+| `kitty` | [Kitty](https://sw.kovidgoyal.net/kitty) | macOS / Linux |
+| `iterm2` | [iTerm2](https://iterm2.com) | macOS |
+| `terminal` | Terminal.app | macOS |
+| `gnome-terminal` | GNOME Terminal | Linux |
+| `konsole` | Konsole | Linux |
+| `xterm` | xterm | Linux |
 
 Session order persists in `~/.tmux/quickdraw-order`. Delete to reset.

--- a/scripts/quickdraw.sh
+++ b/scripts/quickdraw.sh
@@ -144,6 +144,59 @@ move_to_slot() {
   _sl_idx=$target_idx
 }
 
+open_in_terminal() {
+  local session_name=$1
+  local terminal
+  terminal=$(tmux show-option -gqv "@quickdraw-terminal" 2>/dev/null)
+
+  if [ -z "$terminal" ]; then
+    tmux display-message "quickdraw: set @quickdraw-terminal to your terminal"
+    return 1
+  fi
+
+  # POSIX-safe quoting: wrap in single quotes, escape embedded single quotes
+  local safe_name="'${session_name//\'/\'\\\'\'}'"
+  local attach="tmux attach-session -t $safe_name"
+
+  case "$terminal" in
+    ghostty)
+      if [[ "$OSTYPE" == darwin* ]]; then
+        tmux run-shell -b "open -na Ghostty.app --args --command='$attach'"
+      else
+        tmux run-shell -b "ghostty -e $attach"
+      fi
+      ;;
+    alacritty)
+      tmux run-shell -b "alacritty -e $attach"
+      ;;
+    wezterm)
+      tmux run-shell -b "wezterm start -- $attach"
+      ;;
+    kitty)
+      tmux run-shell -b "kitty $attach"
+      ;;
+    iterm2)
+      tmux run-shell -b "osascript -e 'tell application \"iTerm2\" to create window with default profile command \"$attach\"'"
+      ;;
+    terminal)
+      tmux run-shell -b "osascript -e 'tell application \"Terminal\" to do script \"$attach\"'"
+      ;;
+    xterm)
+      tmux run-shell -b "xterm -e $attach"
+      ;;
+    gnome-terminal)
+      tmux run-shell -b "gnome-terminal -- $attach"
+      ;;
+    konsole)
+      tmux run-shell -b "konsole -e $attach"
+      ;;
+    *)
+      tmux display-message "quickdraw: unsupported terminal '$terminal'"
+      return 1
+      ;;
+  esac
+}
+
 inner() {
   trap 'tput cnorm' EXIT
 
@@ -234,6 +287,11 @@ inner() {
         ;;
       k)
         [ "$selected_idx" -gt 0 ] && selected_idx=$((selected_idx - 1))
+        ;;
+      o)
+        if open_in_terminal "${sessions[$selected_idx]}"; then
+          exit 0
+        fi
         ;;
       q)
         exit 0

--- a/scripts/quickdraw.sh
+++ b/scripts/quickdraw.sh
@@ -161,7 +161,23 @@ open_in_terminal() {
   case "$terminal" in
     ghostty)
       if [[ "$OSTYPE" == darwin* ]]; then
-        tmux run-shell -b "open -na Ghostty.app --args --command='$attach'"
+        if pgrep -x Ghostty >/dev/null; then
+          # Escape double quotes for AppleScript string
+          local as_cmd="tmux attach-session -t ${session_name//\"/\\\"}"
+          local tmpfile
+          tmpfile=$(mktemp /tmp/quickdraw-XXXXXX.applescript)
+          {
+            echo 'tell application "System Events" to tell process "Ghostty"'
+            echo '    click menu item "New Window" of menu "File" of menu bar 1'
+            echo '    delay 0.5'
+            echo "    keystroke \"$as_cmd\""
+            echo '    key code 36'
+            echo 'end tell'
+          } > "$tmpfile"
+          tmux run-shell -b "osascript '$tmpfile' ; rm -f '$tmpfile'"
+        else
+          tmux run-shell -b "open -a Ghostty.app --args --command='$attach'"
+        fi
       else
         tmux run-shell -b "ghostty -e $attach"
       fi


### PR DESCRIPTION
## Summary
- Adds `o` key in the quickdraw popup to open the highlighted session in a new terminal window
- New `@quickdraw-terminal` option to configure which terminal emulator to use
- Supports 9 terminals: ghostty, alacritty, wezterm, kitty, iterm2, Terminal.app, gnome-terminal, konsole, xterm
- Platform-aware: ghostty uses `open -na` on macOS and `ghostty -e` on Linux
- POSIX-safe session name quoting for names with special characters

## Test plan
- [ ] Set `@quickdraw-terminal` to your terminal, open quickdraw, press `o` on a session
- [ ] Verify new terminal window opens attached to the correct session
- [ ] Verify `o` without `@quickdraw-terminal` set shows a status bar message
- [ ] Test with session names containing spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)