### PR TITLE
feat: add Shift+J/K to reorder sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Default trigger: `Option/Alt+e` (no prefix required)
 | `Enter` | Switch to session |
 | `o` | Open session in new terminal window |
 | `Number` | Jump to session N |
-| `Shift+↑/↓` or `Opt/Alt+↑/↓` | Reorder session |
+| `Shift+↑/↓` or `Shift+J/K` or `Opt/Alt+↑/↓` | Reorder session |
 | `Shift`+`Number` | Pin to slot 1–10 |
 | `q` / `Esc` | Close |
 

--- a/scripts/quickdraw.sh
+++ b/scripts/quickdraw.sh
@@ -303,12 +303,18 @@ inner() {
           selected_idx=0
         fi
         ;;
+      J)
+        move_session sessions selected_idx "down" "$current_session"
+        ;;
       k)
         if [ "$selected_idx" -gt 0 ]; then
           selected_idx=$((selected_idx - 1))
         else
           selected_idx=$((${#sessions[@]} - 1))
         fi
+        ;;
+      K)
+        move_session sessions selected_idx "up" "$current_session"
         ;;
       o)
         if open_in_terminal "${sessions[$selected_idx]}"; then


### PR DESCRIPTION
## Summary

Adds `Shift+J` and `Shift+K` as additional keybindings for reordering sessions up/down in the list.

This mirrors the existing `Shift+↑/↓` and `Opt/Alt+↑/↓` reordering, but uses the vim-adjacent convention where lowercase `j`/`k` navigate the cursor and uppercase `J`/`K` move the current session.

## Changes
- `scripts/quickdraw.sh` — added `J` and `K` cases that call `move_session` 
- `README.md` — documented the new keybinding

## Keys affected

| Key | Action |
|-----|--------|
| `Shift+J` | Move current session down |
| `Shift+K` | Move current session up |